### PR TITLE
fix: merge module namespace into exports if it already exists

### DIFF
--- a/src/dependencies/goog-loader-suffix-dependency.js
+++ b/src/dependencies/goog-loader-suffix-dependency.js
@@ -25,7 +25,21 @@ class GoogLoaderSuffixDependencyTemplate {
 
     let content = '';
     if (dep.isGoogModule) {
-      content = '\nreturn exports; });';
+      //
+      // If the module was loaded with declareLegacyNamespace, ensure existing
+      // globals on the module path aren't replaced by merging the exports into
+      // the existing object.
+      //
+      // This merge order is intended to preserve the load order of the files.
+      //
+      content = `
+if (goog.moduleLoaderState_.declareLegacyNamespace) {
+  const existingExports = goog.module.get(goog.moduleLoaderState_.moduleName);
+  if (existingExports) {
+    exports = Object.assign(existingExports, exports);
+  }
+}
+return exports; });`;
     }
     content += `
 goog.moduleLoaderState_ = googPreviousLoaderState__;`;


### PR DESCRIPTION
When using `goog.module.declareLegacyNamespace`, if a parent namespace is loaded after the child it will wipe out the global reference to the child.

To reproduce, run this from `opensphere-jscodeshift`:
```
yarn run shift -t src/transforms/es6/providetomodule.js ../opensphere/src/os/events/events.js
```

Then load the debug build of OpenSphere. You'll see errors caused by `os.events` loading after several of its children, which assigns `window.os.events` to the module exports. The fix merges these objects instead of doing a simple assignment. This only impacts the debug build.