### PR TITLE
feat(gcc): update closure compiler to 20210406

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "google-closure-compiler": "^20200830.0.0",
+    "google-closure-compiler": "^20210406.0.0",
     "husky": "^3.1.0",
     "jest": "^24.9.0",
     "lint-staged": "^9.5.0",
@@ -60,7 +60,7 @@
     "node": ">= 6.9.0 || >= 8.9.0"
   },
   "peerDependencies": {
-    "google-closure-compiler": ">=20200830.0.0",
+    "google-closure-compiler": ">=20210406.0.0",
     "webpack": "4.x"
   },
   "homepage": "https://github.com/ngageoint/closure-webpack-plugin",


### PR DESCRIPTION
BREAKING CHANGE: The updated compiler will find additional errors from previous versions, and is not compatible with old versions of the Closure library. Projects will need to update the library and resolve build errors.